### PR TITLE
[fix]: Single Page Apps support for GitHub Pages, Vercel

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,31 @@
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="default" />
   <meta name="apple-mobile-web-app-title" content="KUIS" />
+
+  <!-- Start Single Page Apps for GitHub Pages -->
+  <script type="text/javascript">
+    // Single Page Apps for GitHub Pages
+    // MIT License
+    // https://github.com/rafgraph/spa-github-pages
+    // This script checks to see if a redirect is present in the query string,
+    // converts it back into the correct url and adds it to the
+    // browser's history using window.history.replaceState(...),
+    // which won't cause the browser to attempt to load the new url.
+    // When the single page app is loaded further down in this file,
+    // the correct url will be waiting in the browser's history for
+    // the single page app to route accordingly.
+    (function (l) {
+      if (l.search[1] === '/') {
+        var decoded = l.search.slice(1).split('&').map(function (s) {
+          return s.replace(/~and~/g, '&')
+        }).join('?');
+        window.history.replaceState(null, null,
+          l.pathname.slice(0, -1) + decoded + l.hash
+        );
+      }
+    }(window.location))
+  </script>
+  <!-- End Single Page Apps for GitHub Pages -->
 </head>
 
 <body>


### PR DESCRIPTION
## 🧑🏻‍💻 Key Changes
- react vercel 배포에서 route 경로 안에서 새로고침 시 404뜨는 문제 해결 코드입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured client-side routes work correctly on GitHub Pages. Direct links, bookmarked URLs, and page refreshes on nested routes now load without 404 errors.
  * Cleans up the URL to the expected path while preserving any hash.
  * Improves navigation by avoiding full page reloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->