### PR TITLE
[fix]: add home notice text

### DIFF
--- a/src/components/home/HomeHeader.tsx
+++ b/src/components/home/HomeHeader.tsx
@@ -44,6 +44,11 @@ const HomeHeader = ({ isLoggedIn, userName }: HomeHeaderProps) => {
       <p className="text-lg font-normal leading-[1.4] tracking-[-0.36px] text-black hidden md:block md:text-[28px] md:font-normal md:leading-[2.0] md:tracking-[-0.56]">
         안녕하세요. 건국대학교 학사정보시스템입니다.
       </p>
+      <p className="text-xs mt-4 font-normal leading-[1.4] tracking-[-0.36px] text-danger md:text-[16px] md:font-normal md:leading-[2.0] md:tracking-[-0.56]">
+         본 화면의 학사정보는 예시용 가상 데이터입니다.
+         <br />
+         실제 학사 정보와 무관합니다.
+      </p>
     </>
   );
 };


### PR DESCRIPTION
## 🔗 Issue Link
- closed #37 

<br/>

## 🧑🏻‍💻 Key Changes

메인홈 notice 문구 추가

<br/>

## 🧑🏻‍💻 Screenshots

<img width="2438" height="2704" alt="image" src="https://github.com/user-attachments/assets/9a3e9880-34f2-4a45-8d26-e05d66d92bd4" />

<img width="920" height="1708" alt="image" src="https://github.com/user-attachments/assets/ef38875a-3117-4e57-a600-404c4174a216" />

<br/>

## 🧑🏻‍💻 To Reviewer


<br/>

## 🧑🏻‍💻 Next


<br/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visible disclaimer below the home header greeting stating the displayed academic information is sample data and unrelated to actual records. The message is shown in Korean with a line break for clarity.

* **Style**
  * Introduced small, red text styling for the disclaimer with appropriate top margin.
  * Improved readability with responsive typography: compact on mobile and larger, refined text size and spacing on medium screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->